### PR TITLE
fix Makefile for Linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,18 @@ CPPFLAGS=-DHAS_BLKID
 CFLAGS=-O3 -Wall
 LDLIBS=-lblkid
 
+version.h:
+	if [ ! -f version.h ]; then \
+	if [ -d .git ]; then \
+	echo '#define VERSION_STR "$(shell git describe --tags --abbrev=0)"' > version.h; \
+	else \
+	echo '#define VERSION_STR ""' > version.h; \
+	fi \
+	fi
+
 abootimg.o: bootimg.h version.h
+
+abootimg: abootimg.o
 
 clean:
 	rm -f abootimg *.o version.h


### PR DESCRIPTION
The target for version.h got lost and I took it from the master branch. Also I added a target for abootimg, so the linking will be done automatically when calling just make without a target.